### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -24,6 +24,8 @@ jobs:
   parse-env:
     if: github.repository != 'tschm/.config-templates'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       source-folder: ${{ steps.export.outputs.SOURCE_FOLDER }}
       tests-folder: ${{ steps.export.outputs.TESTS_FOLDER }}


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/.config-templates/security/code-scanning/1](https://github.com/tschm/.config-templates/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `parse-env` job specifying the minimum required permissions. Since the job only checks out the code and parses a file, it only needs read access to repository contents. Therefore, add:

```yaml
permissions:
  contents: read
```

directly under the `runs-on` line (line 26) of the `parse-env` job. This ensures the job does not inherit broader permissions from the repository or organization defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
