### PR TITLE
Include permissions for workflow actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ on:
     - cron: '0 0 * * 1'  # Weekly on Monday at midnight
   workflow_dispatch:  # Allow manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ templates into your project using the GitHub Action provided
 in this repository:
 
 ```yaml
-# .github/workflows/sync-configs.yml
 name: Sync Config Templates
 
 on:
@@ -145,6 +144,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.PAT_TOKEN }}
           branch: sync/update-configs
           title: 'chore: sync configuration templates'
           commit-message: 'chore: sync config files from config-templates'
@@ -152,8 +152,6 @@ jobs:
             This PR updates configuration files from the
             [config-templates](https://github.com/tschm/.config-templates)
             repository.
-
-            - Automated PR created by GitHub Actions
 ```
 
 This action will:


### PR DESCRIPTION
Add permissions section to GitHub Actions workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README workflow example to show repository write permissions so workflows can push commits and create pull requests.
  * Added guidance to supply a Personal Access Token for PR creation.
  * Removed the automated PR body line referencing GitHub Actions.
  * No changes to app behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->