### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,6 +10,9 @@
 #   - 📝 Create a pull request with the changes
 
 name: SYNC
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/.config-templates/security/code-scanning/7](https://github.com/tschm/.config-templates/security/code-scanning/7)

To remediate, add a `permissions` block to the top level of the workflow (or to the specific job) to restrict GITHUB_TOKEN’s permissions to the least required for the workflow's operation. Since the workflow syncs files and creates pull requests, usually it requires at least `contents: write` and `pull-requests: write`. However, since it uses a PAT for syncing, you may get away with `contents: read` for GITHUB_TOKEN and only allow additional permissions if required by other steps. The best general solution is to restrict GITHUB_TOKEN as much as possible but allow what’s necessary for the pull request creation. The change should be made after the `name:` block and before `on:` or after `on:` and before `jobs:` (top-level). The fix does not impact existing workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sync automation workflow to use explicit, least-privilege permissions, enabling read access to repository contents and write access for pull requests.
  * Improves reliability of automated sync tasks in restricted environments and enhances auditability of workflow permissions.
  * No changes to workflow triggers or job logic.
  * No impact on application behavior or release artifacts; end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->