### PR TITLE
Fix badge formatting for Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🛠️ Config Templates
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Python]](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)
+[![Python versions](https://img.shields.io/badge/Python-3.11%20•%203.12%20•%203.13-blue?logo=python)](https://www.python.org/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg?logo=ruff)](https://github.com/astral-sh/ruff)
 
 [![CI Status](https://github.com/tschm/.config-templates/workflows/CI/badge.svg)](https://github.com/tschm/.config-templates/actions)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Python versions badge in the README: replaced the previous badge with a versions badge that includes a logo and links to python.org, altering how supported Python versions are displayed. No changes to code behavior or exported/public declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->