### PR TITLE
added UV_NO_MODIFY_PATH as True to avoid mutating users shell on install

### DIFF
--- a/taskfiles/build.yml
+++ b/taskfiles/build.yml
@@ -22,6 +22,7 @@ tasks:
     desc: Install uv and uvx
     env:
       UV_INSTALL_DIR: ./bin
+      UV_NO_MODIFY_PATH: 1
     cmds:
       - |
         if [ -x "${UV_INSTALL_DIR}/uv" ] && [ -x "${UV_INSTALL_DIR}/uvx" ]; then


### PR DESCRIPTION
When running `make install` UV is installed into a bin folder in the root of the repo. UV automatically adds the path of the install to the users shell config (`.zshrc`, `.bashrc`, etc.) which can cause issues once `make clean` is invoked or if they have a global install. 

I have added `UV_NO_MODIFY_PATH=1` to the env var of the task `build:uv`. This keeps the install totally isolated from anything the user may have configured outside of this. 

When `make clean` is run currently the following still remains in the users shell.

<img width="327" height="57" alt="Screenshot 2025-11-23 at 14 49 16" src="https://github.com/user-attachments/assets/e39f653c-7db5-4ddd-a064-0595c76613b7" />

This is less of an issue when running in a devcontainer or as pipelines as the shell is not persisting but in a local environment it can cause shell issues. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build task configuration to control environment behavior during the installation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->