### PR TITLE
Add 'Private :: Do Not Upload' classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 keywords = ["templates", "configuration", "taskfile", "ci", "ruff"]
 classifiers = [
+  "Private :: Do Not Upload",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Following [packaging.python.org](https://github.com/pypa/packaging.python.org) we can set a classifier to avoid 'accidental' pushes to pypi. I think this is nice default behaviour to use https://github.com/pypa/packaging.python.org/pull/1056/commits/df8113cbd4eaaafa60ffbd70ad24b1dbcec30998

I understand that https://github.com/tschm/.config-templates/pull/161 resolves this in a more explicit way, so perhaps this is unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to mark the project as private.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->