### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_devcontainer.yml
+++ b/.github/workflows/_devcontainer.yml
@@ -35,6 +35,8 @@
 #     with packages:write permission as the calling workflow's secrets.
 #
 name: REUSABLE DEVCONTAINER BUILD
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/.config-templates/security/code-scanning/8](https://github.com/tschm/.config-templates/security/code-scanning/8)

To fix the issue, you should explicitly add a `permissions` block to the workflow, either at the root level (to apply to all jobs), or inside the `devcontainer-build` job (to affect only that job). Since this workflow's steps require checkout (read access to `contents`) and authenticate for registry publishing (using secrets, but not writing to repository or issues), the minimal sensible permission is `contents: read`. If future requirements include other write permissions (e.g., writing to packages or issues), those should be granted as needed, but for now, `contents: read` is recommended.  
Changes required:  
- Insert `permissions:` block after the workflow `name:` key and before the `on:` block at the top of the workflow file.
- Set `contents: read` as the only permission granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security permissions handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->