### PR TITLE
add debugger tools for invoking custom scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,5 +230,20 @@ customisations: ## list available customisation scripts
 	fi
 
 # debugger tools
+custom-%: ## run a custom script (usage: make custom-scriptname)
+	@SCRIPT="${CUSTOM_SCRIPTS_FOLDER}/$*.sh"; \
+	if [ -x "$$SCRIPT" ]; then \
+		printf "${BLUE}[INFO] Running custom script $$SCRIPT...${RESET}\n"; \
+		"$$SCRIPT"; \
+	elif [ -f "$$SCRIPT" ]; then \
+		printf "${BLUE}[INFO] Running custom script $$SCRIPT with /bin/sh...${RESET}\n"; \
+		/bin/sh "$$SCRIPT"; \
+	else \
+		printf "${RED}[ERROR] Custom script '$$SCRIPT' not found.${RESET}\n"; \
+		printf "Available scripts:\n"; \
+		ls -1 "${CUSTOM_SCRIPTS_FOLDER}"/*.sh 2>/dev/null | xargs -n1 basename | sed 's/\.sh$$//' | sed 's/^/  - /'; \
+		exit 1; \
+	fi
+
 print-% :
 	@echo $* = $($*)


### PR DESCRIPTION
This pull request introduces a new Makefile target to streamline the execution of custom scripts. The main improvement is the addition of a `custom-%` target, which allows users to run any script from the designated custom scripts folder by simply invoking `make custom-scriptname`. This enhancement improves developer productivity and script discoverability.

Custom script execution:

* Added the `custom-%` target to the `Makefile`, enabling easy execution of custom scripts located in the `CUSTOM_SCRIPTS_FOLDER`. The target checks if the script is executable, falls back to running with `/bin/sh` if not, and provides a helpful error message listing available scripts when the requested script is missing.

<img width="699" height="234" alt="Screenshot 2025-12-03 at 20 28 13" src="https://github.com/user-attachments/assets/5298e13d-b6b1-4d40-b2be-2e853c3ab9bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new make target for running custom scripts with automatic fallback execution modes and helpful error messaging when scripts are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->